### PR TITLE
Add seed control support

### DIFF
--- a/precilaser/amplifier.py
+++ b/precilaser/amplifier.py
@@ -153,10 +153,10 @@ class Amplifier(AbstractPrecilaserDevice):
         """
         current_int = int(round(current * 100, 0))
         message = self._generate_message(
-            PrecilaserCommand.AMP_SET_CURRENT, current_int.to_bytes(2, self.endian)
+            PrecilaserCommand.SET_CURRENT, current_int.to_bytes(2, self.endian)
         )
         self._write(message)
-        self._read_until_reply(PrecilaserReturn.AMP_SET_CURRENT)
+        self._read_until_reply(PrecilaserReturn.SET_CURRENT)
 
     def enable(self) -> None:
         """
@@ -166,10 +166,10 @@ class Amplifier(AbstractPrecilaserDevice):
             ValueError: raises if the amplifier isn't enabled
         """
         message = self._generate_message(
-            PrecilaserCommand.AMP_ENABLE, 0b111.to_bytes(1, self.endian)
+            PrecilaserCommand.ENABLE, 0b111.to_bytes(1, self.endian)
         )
         self._write(message)
-        message = self._read_until_reply(PrecilaserReturn.AMP_ENABLE)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
         if message.payload != b"Enable set ok":
             raise ValueError(f"Amplifier not enabled; {message.payload!r}")
 
@@ -181,10 +181,10 @@ class Amplifier(AbstractPrecilaserDevice):
             ValueError: raises if the amplifier isn't disabled
         """
         message = self._generate_message(
-            PrecilaserCommand.AMP_ENABLE, 0b0.to_bytes(1, self.endian)
+            PrecilaserCommand.ENABLE, 0b0.to_bytes(1, self.endian)
         )
         self._write(message)
-        message = self._read_until_reply(PrecilaserReturn.AMP_ENABLE)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
         if message.payload != b"Enable set ok":
             raise ValueError(f"Amplifier not disabled; {message.payload!r}")
 
@@ -210,7 +210,7 @@ class Amplifier(AbstractPrecilaserDevice):
         """
         message = self._generate_message(PrecilaserCommand.AMP_POWER_STAB, b"\x01")
         self._write(message)
-        message = self._read_until_reply(PrecilaserReturn.AMP_ENABLE)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
         if message.payload != b"Stable set ok":
             raise ValueError(f"Power stabilization not enabled: {message.payload!r}")
 
@@ -223,7 +223,7 @@ class Amplifier(AbstractPrecilaserDevice):
         """
         message = self._generate_message(PrecilaserCommand.AMP_POWER_STAB, b"\x00")
         self._write(message)
-        message = self._read_until_reply(PrecilaserReturn.AMP_ENABLE)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
         if message.payload != b"Stable set ok":
             raise ValueError(f"Power stabilization not disabled: {message.payload!r}")
 

--- a/precilaser/enums.py
+++ b/precilaser/enums.py
@@ -2,8 +2,8 @@ from enum import Enum, auto
 
 
 class PrecilaserCommand(Enum):
-    AMP_ENABLE = b"\x30"
-    AMP_SET_CURRENT = b"\xa1"
+    ENABLE = b"\x30"  # same for seed & amplifier
+    SET_CURRENT = b"\xa1"  # same for seed & amplifier
     AMP_POWER_STAB = b"\x47"
     AMP_TEC_TEMPERATURE = b"\x87"
     AMP_STATUS = b"\x04"
@@ -16,8 +16,8 @@ class PrecilaserCommand(Enum):
 
 
 class PrecilaserReturn(Enum):
-    AMP_ENABLE = b"\x40"
-    AMP_SET_CURRENT = b"\x41"
+    ENABLE = b"\x40"  # same for seed & amplifier
+    SET_CURRENT = b"\x41"  # same for seed & amplifier
     AMP_POWER_STAB = b"I"
     AMP_TEC_TEMPERATURE = b"\x45"
     AMP_STATUS = b"\x44"

--- a/precilaser/message.py
+++ b/precilaser/message.py
@@ -7,8 +7,8 @@ from .enums import PrecilaserCommand, PrecilaserMessageType, PrecilaserReturn
 
 @dataclass
 class PrecilaserCommandParamLength:
-    AMP_ENABLE: int = 1
-    AMP_SET_CURRENT: int = 2
+    ENABLE: int = 1
+    SET_CURRENT: int = 2
     AMP_POWER_STAB: int = 1
     AMP_TEC_TEMPERATURE: int = 4
     AMP_STATUS: int = 0
@@ -22,8 +22,8 @@ class PrecilaserCommandParamLength:
 
 @dataclass
 class PrecilaserReturnParamLength:
-    AMP_ENABLE: int = 13
-    AMP_SET_CURRENT: int = 46
+    ENABLE: int = 13
+    SET_CURRENT: int = 46
     AMP_POWER_STAB: int = 13
     AMP_TEC_TEMPERATURE: int = 17
     AMP_STATUS: int = 64

--- a/precilaser/seed.py
+++ b/precilaser/seed.py
@@ -1,8 +1,12 @@
 from typing import Optional, Tuple
 
+import time
+
 from .device import AbstractPrecilaserDevice
-from .enums import PrecilaserCommand, PrecilaserDeviceType
-from .status import SeedStatus
+from .enums import PrecilaserCommand, PrecilaserDeviceType, PrecilaserReturn
+from .status import SeedStatus, AmplifierStatus
+
+from .amplifier import status_handler
 
 
 class Seed(AbstractPrecilaserDevice):
@@ -72,9 +76,9 @@ class Seed(AbstractPrecilaserDevice):
 
     @piezo_voltage.setter
     def piezo_voltage(self, voltage: float):
-        assert (
-            voltage >= 0 and voltage <= 74
-        ), "Piezo voltage cannot exceed 0V-74V range"
+        assert voltage >= 0 and voltage <= 74, (
+            "Piezo voltage cannot exceed 0V-74V range"
+        )
         setpoint = int(voltage * 100)
         self._set_value(setpoint, PrecilaserCommand.SEED_SET_VOLTAGE)
         message = self._read()
@@ -82,44 +86,6 @@ class Seed(AbstractPrecilaserDevice):
             self._check_write_return(message.payload[:2], setpoint, "piezo voltage")
         else:
             raise ValueError(f"not set to requested value: {setpoint}")
-
-    # def enable(self):
-    #     # supplied programming manual is incorrect, e.g. also the command and return
-    #     # enums
-    #     # self._set_value(True, PrecilaserCommand.SEED_ENABLE, nbytes=1)
-    #     # byte 13 is set to 1
-    #     enable_bytes = (
-    #         b"P\x00d\xa7\x19a\xa8a\xa8\x01\xf4\x00\x00\x00\x00\x00\x00\x00\x01\x01d"
-    #         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x91K\r\n"
-    #     )
-    #     self.instrument.write_raw(enable_bytes)
-    #     # enabling/disabling the laser returns a status message, where in the first
-    #     # received message after sending the command bit 13 is set to indicate
-    #     # a change in emission state
-    #     message = self._read()
-    #     if message.payload is None or message.payload[13] != 1:
-    #         raise ValueError("emission not enabled")
-    #     # message = self._read()
-    #     # self._check_write_return(message.payload, True, "enable laser")
-
-    # def disable(self):
-    #     # supplied programming manual is incorrect, e.g. also the command and return
-    #     # enums
-    #     # self._set_value(False, PrecilaserCommand.SEED_ENABLE, nbytes=1)
-    #     # byte 13 is set to 0
-    #     disable_bytes = (
-    #         b"P\x00d\xa7\x19a\xa8a\xa8\x01\xf4\x00\x00\x00\x00\x00\x00\x00\x00\x01d\x00"
-    #         b"\x00\x00\x00\x00\x00\x00\x00\x00\x90J\r\n"
-    #     )
-    #     self.instrument.write_raw(disable_bytes)
-    #     # enabling/disabling the laser returns a status message, where in the first
-    #     # received message after sending the command bit 13 is set to indicate
-    #     # a change in emission state
-    #     message = self._read()
-    #     if message.payload is None or message.payload[13] != 1:
-    #         raise ValueError("emission not disabled")
-    #     # message = self._read()
-    #     # self._check_write_return(message.payload, False, "disable laser")
 
     def _get_serial_wavelength_params(self):
         message = self._generate_message(PrecilaserCommand.SEED_SERIAL_WAV)
@@ -133,9 +99,9 @@ class Seed(AbstractPrecilaserDevice):
     def wavelength(self) -> float:
         status = self.status
         temp_grating_act = status.temperature_act * 1_000
-        assert (
-            self.wavelength_params is not None
-        ), "Wavelength parameters not loaded from device"
+        assert self.wavelength_params is not None, (
+            "Wavelength parameters not loaded from device"
+        )
         parameter = self.wavelength_params
         wavelength = (
             (parameter[0] << 8) | parameter[1]
@@ -150,15 +116,160 @@ class Seed(AbstractPrecilaserDevice):
     @wavelength.setter
     def wavelength(self, wavelength: float):
         status = self.status
-        assert (
-            self.wavelength_params is not None
-        ), "Wavelength parameters not loaded from device"
+        assert self.wavelength_params is not None, (
+            "Wavelength parameters not loaded from device"
+        )
         parameter = self.wavelength_params
-        temp_grating_act = (wavelength * 10_000 - (
-            parameter[2] << 24
-            | parameter[3] << 16
-            | ((parameter[4] << 8) | parameter[5])
-        )) * 10_000 /  ((parameter[0] << 8) | parameter[1]
-        )  
+        temp_grating_act = (
+            (
+                wavelength * 10_000
+                - (
+                    parameter[2] << 24
+                    | parameter[3] << 16
+                    | ((parameter[4] << 8) | parameter[5])
+                )
+            )
+            * 10_000
+            / ((parameter[0] << 8) | parameter[1])
+        )
         temp_set = temp_grating_act / 1_000
         self.temperature_setpoint = temp_set
+
+
+class SeedControl(AbstractPrecilaserDevice):
+    def __init__(
+        self,
+        resource_name: str,
+        address: int,
+        header: bytes = b"P",
+        terminator: bytes = b"\r\n",
+        device_type: PrecilaserDeviceType = PrecilaserDeviceType.SEED,
+        endian: str = "big",
+    ):
+        super().__init__(
+            resource_name, address, header, terminator, device_type, endian
+        )
+        self.serial: bytes | None = None
+        self.wavelength_params: tuple[int, ...] | None = None
+        self._message_handling[PrecilaserReturn.AMP_STATUS] = (
+            "_status",
+            status_handler,
+        )
+
+    def enable(self) -> None:
+        """Enables the seed.
+
+        Raises:
+            ValueError: if the seed has not been enabled
+        """
+        self._set_value(1, PrecilaserCommand.ENABLE, nbytes=1)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
+        if message.payload != b"Enable set ok":
+            raise ValueError("emission not enabled")
+
+    def disable(self) -> None:
+        """Disables the seed.
+
+        Raises:
+            ValueError: if the seed has not been disabled
+        """
+        self._set_value(0, PrecilaserCommand.ENABLE, nbytes=1)
+        message = self._read_until_reply(PrecilaserReturn.ENABLE)
+        # The laser's answer is the same for disable / enable
+        if message.payload != b"Enable set ok":
+            raise ValueError("emission not disabled")
+
+    def _set_value(
+        self,
+        value: int,
+        command: PrecilaserCommand,
+        nbytes: int = 2,
+    ) -> None:
+        """Sets a value by writing on the seed.
+
+        Args:
+            value: The desired value
+            command: The command associated to the value to write
+            nbytes: The number of bytes the value should take
+        """
+        # Unlike the seed comm port there is no "save" parameter here
+        payload = value.to_bytes(nbytes, self.endian)
+        message = self._generate_message(command, payload)
+
+        self._write(message)
+
+    # The control port of the seed is actually a small amplifier according to Precilaser.
+    # Which is why some commands from Amplifier are reused.
+    @property
+    def status(self) -> AmplifierStatus:
+        """Reads the buffer until a status is encountered.
+        The seed returns it regularly and it's handled by status_handler
+
+        Returns:
+            The updated status
+        Raises:
+            ValueError: if the status is None
+        """
+        self._read_until_reply(PrecilaserReturn.AMP_STATUS)
+        if self._status is None:
+            raise ValueError("No status retrieved")
+        return self._status
+
+    @property
+    def current(self) -> float:
+        """Amplifier current [A] of all stages.
+
+        Returns:
+            amplifier current [A] of all stages
+        """
+        self._read_until_reply(PrecilaserReturn.AMP_STATUS)
+        return sum(self.status.driver_current)
+
+    @current.setter
+    def current(self, current: float) -> None:
+        """Set the amplifier current.
+
+        Args:
+            current (float): current [A]
+        """
+        current_int = int(round(current * 100, 0))
+        self._set_value(current_int, PrecilaserCommand.SET_CURRENT)
+        self._read_until_reply(PrecilaserReturn.SET_CURRENT)
+
+    def set_current_down(self, current: int) -> None:
+        """Sets the current down on the amplifier.
+
+        Args:
+            current: The desired current
+        Raises:
+            ValueError: if the current is not set correctly
+        """
+        if current >= self.current:
+            raise ValueError("Actual current cannot be lower than current setting")
+        while self.current > current:
+            if self.current - 1 <= current:
+                self.current = current
+                break
+            self.current = self.current - 1
+            time.sleep(10)
+
+        if self.current != current:
+            raise ValueError("Current setting was not set correctly.")
+
+    def set_current_up(self, current: int) -> None:
+        """Sets the current up on the amplifier.
+
+        Args:
+            current: the desired current
+        Raises:
+            ValueError: If the current is not set correctly
+        """
+        while self.current < current:
+            if self.current + 1 >= current:
+                self.current = current
+                break
+            self.current = self.current + 1
+            time.sleep(10)
+
+        if self.current != current:
+            raise ValueError("Current setting was not set correctly.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "precilaser"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["ograsdijk <o.grasdijk@gmail.com>"]
 readme = "README.md"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -7,7 +7,7 @@ from precilaser.message import (
 
 
 def test_PrecilaserMessage():
-    for command in [PrecilaserCommand.AMP_SET_CURRENT]:
+    for command in [PrecilaserCommand.SET_CURRENT]:
         value = int(1.5 * 100)
         param_length = getattr(PrecilaserCommandParamLength, command.name)
         payload = value.to_bytes(param_length, "big")


### PR DESCRIPTION
This PR adds support for the enabling / disabling of the seed & setting its current.

This is the result of some tests with Wireshark and what Precilaser told me by email.

The code is a bit counterintuitive but each 17xx nm seed should have 2 ports. A "Control" port, with which we can enable the seed and set its current, and a "comm" port for the status, wavelength etc...  Precilaser explained to me that the device behind this "Control" port is basically the same as an amplifier (which is why the commands are very similar). 

So we add a new class SeedControl which represents this new "device" that allow us to send these commands to the seed.